### PR TITLE
Add daily notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-link of the website : https://quvntvn-qotd-website.netlify.app
+Link of the website : https://quvntvn-qotd-website.netlify.app
+
+## Notifications
+
+The site now includes a button to enable daily notifications at 10am. When
+enabled, your browser will show the quote of the day along with the author and
+year (when available). Notifications work on browsers that support the Web
+Notification API.


### PR DESCRIPTION
## Summary
- add a button to enable daily notifications at 10am
- show notification with quote, author and year if available

## Testing
- `npm install`
- `npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_686b93ae10a4832388389dec52cb322e