### PR TITLE
Enable service worker notifications

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,20 @@
+self.addEventListener('install', event => {
+  self.skipWaiting();
+});
+
+self.addEventListener('push', event => {
+  let data = {};
+  if (event.data) {
+    try {
+      data = event.data.json();
+    } catch (err) {
+      data = { title: 'Notification', body: event.data.text() };
+    }
+  }
+  const title = data.title || 'Notification';
+  const options = {
+    body: data.body || '',
+    icon: '/logo192.png'
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});

--- a/src/index.js
+++ b/src/index.js
@@ -11,3 +11,11 @@ root.render(
   </React.StrictMode>
 );
 reportWebVitals();
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch(err => {
+      console.error('Service worker registration failed:', err);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- register a service worker at startup
- add a basic `sw.js` that listens for `push` events

## Testing
- `npm ci`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6870f2464048832389ca2487b8a627ed